### PR TITLE
simple round robin load balancer without a queue

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ pub mod traits;
 extern crate rand;
 
 use crate::objects::{World, Scheduler};
-use crate::systems::{ArrivalSource, Server, EndSink, System};
+use crate::systems::{ArrivalSource, Server, EndSink, LoadBalancer, System};
 use crate::traits::StatEmitter;
 
 use rand_distr::Poisson;
@@ -20,10 +20,16 @@ fn main() {
 
     let up_to_nano = 1_000_000_000;
     
-    let server = Server::new(Poisson::<f64>::new(20_000.0).unwrap(), endsink_ref);
-    let server_ref = world.add(System::Server(server));
+    let server1 = Server::new(Poisson::<f64>::new(20_000.0).unwrap(), endsink_ref);
+    let server1_ref = world.add(System::Server(server1));
 
-    let ar = ArrivalSource::new( Poisson::<f64>::new(1_000.0).unwrap(), server_ref);
+    let server2 = Server::new(Poisson::<f64>::new(20_000.0).unwrap(), endsink_ref);
+    let server2_ref = world.add(System::Server(server2));
+
+    let load_balancer = LoadBalancer::new(vec![server1_ref, server2_ref]);
+    let load_balancer_ref = world.add(System::LoadBalancer(load_balancer));
+
+    let ar = ArrivalSource::new( Poisson::<f64>::new(1_000.0).unwrap(), load_balancer_ref);
     let ar_ref = world.add(System::ArrivalSource(ar));
     
     let mut scheduler = Scheduler::new();
@@ -37,6 +43,8 @@ fn main() {
     
     
     world.with_system(ar_ref, |ar, _w|{println!("ar {}", ar.stats());});
-    world.with_system(server_ref, |server, _w| println!("server {}", server.stats()) );
+    world.with_system(server1_ref, |server, _w| println!("server1 {}", server.stats()) );
+    world.with_system(server2_ref, |server, _w| println!("server2 {}", server.stats()) );
+    world.with_system(load_balancer_ref, |load_balancer, _w| println!("load balaner {}", load_balancer.stats()) );
     world.with_system(endsink_ref, |endsink, _w| println!("endsink {}", endsink.stats()) );
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -14,7 +14,7 @@ pub trait Emmitter {
 }
 
 pub trait Sink {
-    fn next(&mut self, scheduler: &mut Scheduler);
+    fn next(&mut self, world: &mut World, scheduler: &mut Scheduler);
 }
 
 pub trait StatEmitter {


### PR DESCRIPTION
added a simple round robin loadbalancer which as soon as input comes sends it to the next server.

adding 2 servers behind a loadbalancer produces:
```
     Running `target/release/system-design-model-rust`
executed executed 1,099,993
ar as 1,000.005
server1 meter 20,000.276 queue 449,999 counter 499,998
server2 meter 20,000.264 queue 450,000 counter 499,998
load balaner lb incoming 999,996
endsink 99,997
```

before, 1 server:
```
executed executed 1,050,011
ar as 999.988
server meter 20,000.027 queue 950,013 counter 1,000,012
endsink 49,999
```

the stats are hard to read, thats the next improvement maybe.