### PR TITLE
counting all requests in progress in the system

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,8 @@ extern crate rand;
 
 use crate::objects::{World, Scheduler};
 use crate::systems::{ArrivalSource, Server, EndSink, LoadBalancer, System};
-use crate::traits::StatEmitter;
+use crate::traits::{StatEmitter, HasQueue};
+use crate::utils::tostring;
 
 use rand_distr::Poisson;
 
@@ -47,4 +48,6 @@ fn main() {
     world.with_system(server2_ref, |server, _w| println!("server2 {}", server.stats()) );
     world.with_system(load_balancer_ref, |load_balancer, _w| println!("load balaner {}", load_balancer.stats()) );
     world.with_system(endsink_ref, |endsink, _w| println!("endsink {}", endsink.stats()) );
+
+    println!("requests in the system {}", tostring(world.queue_size()));
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,4 +1,4 @@
-use crate::traits::{SystemRef, StatEmitter, WorldMember};
+use crate::traits::{SystemRef, StatEmitter, WorldMember, HasQueue};
 use crate::systems::System;
 
 pub struct World {
@@ -34,6 +34,16 @@ impl World {
             systems: nsystems
         };
         (unset, nw)
+    }
+}
+
+impl HasQueue for World {
+    fn queue_size(&self) -> i64 {
+        let mut qs = 0;
+        for system in &self.systems {
+            qs += system.queue_size();
+        }
+        qs
     }
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,6 +1,6 @@
 
 use crate::objects::{Scheduler, World};
-use crate::traits::{SystemRef, StatEmitter, Emmitter, WorldMember, Sink};
+use crate::traits::{SystemRef, StatEmitter, Emmitter, WorldMember, Sink, HasQueue};
 use crate::utils::{Counter, Meter, tostring};
 
 use rand_distr::Distribution;
@@ -202,6 +202,11 @@ impl StatEmitter for Server {
     }
 }
 
+impl HasQueue for Server {
+    fn queue_size(&self) -> i64 {
+        self.queue.len() as i64
+    }
+}
 
 
 pub enum System {
@@ -231,6 +236,16 @@ impl System {
                 System::Unset => unimplemented!(),
                 System::LoadBalancer(lb) => lb.next(world, scheduler),
             }
+    }
+
+    pub fn queue_size(&self) -> i64 {
+        match self {
+            System::Unset => 0,
+            System::EndSink(_) => 0,
+            System::Server(s) => s.queue_size(),
+            System::ArrivalSource(_) => 0,
+            System::LoadBalancer(_) => 0,
+        }
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,3 +20,7 @@ pub trait Sink {
 pub trait StatEmitter {
     fn stats(&self) -> String;
 }
+
+pub trait HasQueue {
+    fn queue_size(&self) -> i64;
+}


### PR DESCRIPTION
one of the interesting characteristics to see is little's law.
n of requests in progress = arrival rate * latency.

this pr allows counting requests in progress.

```
     Running `target/release/system-design-model-rust`
executed executed 1,100,013
ar as 999.988
server1 meter 19,999.897 queue 450,007 counter 500,007
server2 meter 20,000.014 queue 450,006 counter 500,006
load balaner lb incoming 1,000,013
endsink 100,000
requests in the system 900,013
```